### PR TITLE
fix: offset handling error malfunction

### DIFF
--- a/src/Lexers/RuntimeLexer.php
+++ b/src/Lexers/RuntimeLexer.php
@@ -13,7 +13,7 @@ class RuntimeLexer implements LexerInterface
 
     protected Closure $produceTokenUsing;
 
-    protected string $skip;
+    protected ?string $skip;
 
     protected ?UnitEnum $errorType = null;
 
@@ -80,12 +80,16 @@ class RuntimeLexer implements LexerInterface
         return $tokens;
     }
 
-    protected function findNextMatchAndProduceError(string $input, int &$offset): array
+    protected function findNextMatchAndProduceError(string $input, int $offset): array
     {
         $patterns = [...array_keys($this->patterns), $this->skip];
         $offsets = [];
 
         foreach ($patterns as $pattern) {
+            if ($pattern === null) {
+                continue;
+            }
+
             if (! preg_match('/'.$pattern.'/', $input, $matches, PREG_OFFSET_CAPTURE, $offset)) {
                 continue;
             }
@@ -96,8 +100,6 @@ class RuntimeLexer implements LexerInterface
         $skipped = count($offsets) > 0
             ? substr($input, $offset, min($offsets) - $offset)
             : substr($input, $offset, strlen($input) - $offset);
-
-        $offset = count($offsets) > 0 ? min($offsets) : ($offset + (strlen($input) - $offset));
 
         return [$skipped, $this->errorType];
     }

--- a/tests/Examples/MarkdownTest.php
+++ b/tests/Examples/MarkdownTest.php
@@ -22,6 +22,6 @@ test('markdown > can tokenise bold', function () {
         ->toBe([
             [MarkdownTokenType::Text, 'Lorem '],
             [MarkdownTokenType::Bold, '**ipsum**'],
-            [MarkdownTokenType::Text, ' ahmet sun']
+            [MarkdownTokenType::Text, ' ahmet sun'],
         ]);
 });

--- a/tests/Examples/MarkdownTest.php
+++ b/tests/Examples/MarkdownTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use RyanChandler\Lexical\Attributes\Error;
+use RyanChandler\Lexical\Attributes\Regex;
+use RyanChandler\Lexical\LexicalBuilder;
+
+enum MarkdownTokenType
+{
+    #[Regex("\*\*(.*?)\*\*")]
+    case Bold;
+
+    #[Error]
+    case Text;
+}
+
+test('markdown > can tokenise bold', function () {
+    $lexer = (new LexicalBuilder)
+        ->readTokenTypesFrom(MarkdownTokenType::class)
+        ->build();
+
+    expect($lexer->tokenise('Lorem **ipsum** ahmet sun'))
+        ->toBe([
+            [MarkdownTokenType::Text, 'Lorem '],
+            [MarkdownTokenType::Bold, '**ipsum**'],
+            [MarkdownTokenType::Text, ' ahmet sun']
+        ]);
+});


### PR DESCRIPTION
Closes #3.

The error handling mechanism that would produce an `#[Error]` token type was taking the `$offset` by reference and modifying it, when it didn't need to since the main tokenisation logic was already handling it correctly.