### PR TITLE
feature: track token spans (start/end offsets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ The `readTokenTypesFrom()` method is used to tell the builder where we should lo
 Then it's just a case of calling the `tokenise()` method on the lexer object to retrieve an array of tokens.
 
 ```php
-$tokens = $lexer->tokenise('1+2'); // -> [[TokenType::Number, '1'], [TokenType::Add, '+'], [TokenType::Number, '2']]
+$tokens = $lexer->tokenise('1+2'); // -> [[TokenType::Number, '1', Span(0, 1)], [TokenType::Add, '+', Span(1, 2)], [TokenType::Number, '2', Span(2, 3)]]
 ```
 
-The `tokenise()` method returns a list of tuples, where the first item is the "type" (`TokenType` in this example) and the second item is the "literal" (a string containing the matched characters).
+The `tokenise()` method returns a list of tuples, where the first item is the "type" (`TokenType` in this example), the second item is the "literal" (a string containing the matched characters) and the third item is the "span" of the token (the start and end positions in the original string).
 
 ### Skipping whitespace and other patterns
 
@@ -130,12 +130,13 @@ class Token
     public function __construct(
         public readonly TokenType $type,
         public readonly string $literal,
+        public readonly Span $span,
     ) {}
 }
 
 $lexer = (new LexicalBuilder)
     ->readTokenTypesFrom(TokenType::class)
-    ->produceTokenUsing(fn (TokenType $type, string $literal) => new Token($type, $literal))
+    ->produceTokenUsing(fn (TokenType $type, string $literal, Span $span) => new Token($type, $literal, $span))
     ->build();
 
 $lexer->tokenise('1 + 2'); // -> [Token { type: TokenType::Number, literal: "1" }, ...]

--- a/src/Lexers/RuntimeLexer.php
+++ b/src/Lexers/RuntimeLexer.php
@@ -5,6 +5,7 @@ namespace RyanChandler\Lexical\Lexers;
 use Closure;
 use RyanChandler\Lexical\Contracts\LexerInterface;
 use RyanChandler\Lexical\Exceptions\UnexpectedCharacterException;
+use RyanChandler\Lexical\Span;
 use UnitEnum;
 
 class RuntimeLexer implements LexerInterface
@@ -73,8 +74,9 @@ class RuntimeLexer implements LexerInterface
                 $token = [$matches[$m], $this->markToTypeMap[$m]];
             }
 
-            $tokens[] = call_user_func($this->produceTokenUsing, $token[1], $token[0]);
+            $start = $offset;
             $offset += strlen($token[0]);
+            $tokens[] = call_user_func($this->produceTokenUsing, $token[1], $token[0], new Span($start, $offset));
         }
 
         return $tokens;

--- a/src/LexicalBuilder.php
+++ b/src/LexicalBuilder.php
@@ -23,7 +23,7 @@ class LexicalBuilder
 
     public function __construct()
     {
-        $this->produceTokenUsing = fn (UnitEnum $type, string $literal) => [$type, $literal];
+        $this->produceTokenUsing = fn (UnitEnum $type, string $literal, Span $span) => [$type, $literal, $span];
     }
 
     public function readTokenTypesFrom(string $class): static

--- a/src/Span.php
+++ b/src/Span.php
@@ -7,5 +7,6 @@ class Span
     public function __construct(
         protected int $start,
         protected int $end,
-    ) {}
+    ) {
+    }
 }

--- a/src/Span.php
+++ b/src/Span.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace RyanChandler\Lexical;
+
+class Span
+{
+    public function __construct(
+        protected int $start,
+        protected int $end,
+    ) {}
+}

--- a/tests/Examples/MarkdownTest.php
+++ b/tests/Examples/MarkdownTest.php
@@ -3,6 +3,7 @@
 use RyanChandler\Lexical\Attributes\Error;
 use RyanChandler\Lexical\Attributes\Regex;
 use RyanChandler\Lexical\LexicalBuilder;
+use RyanChandler\Lexical\Span;
 
 enum MarkdownTokenType
 {
@@ -19,9 +20,9 @@ test('markdown > can tokenise bold', function () {
         ->build();
 
     expect($lexer->tokenise('Lorem **ipsum** ahmet sun'))
-        ->toBe([
-            [MarkdownTokenType::Text, 'Lorem '],
-            [MarkdownTokenType::Bold, '**ipsum**'],
-            [MarkdownTokenType::Text, ' ahmet sun'],
+        ->toMatchArray([
+            [MarkdownTokenType::Text, 'Lorem ', new Span(0, 6)],
+            [MarkdownTokenType::Bold, '**ipsum**', new Span(6, 15)],
+            [MarkdownTokenType::Text, ' ahmet sun', new Span(15, 25)],
         ]);
 });

--- a/tests/LexicalTest.php
+++ b/tests/LexicalTest.php
@@ -6,6 +6,7 @@ use RyanChandler\Lexical\Attributes\Literal;
 use RyanChandler\Lexical\Attributes\Regex;
 use RyanChandler\Lexical\Exceptions\UnexpectedCharacterException;
 use RyanChandler\Lexical\LexicalBuilder;
+use RyanChandler\Lexical\Span;
 
 it('can produce the correct tokens for the given math expression', function () {
     $lexer = (new LexicalBuilder)
@@ -13,16 +14,16 @@ it('can produce the correct tokens for the given math expression', function () {
         ->build();
 
     expect($lexer->tokenise('1 + 2 - 3 * 4 / 5'))
-        ->toBe([
-            [MathTestToken::Number, '1'],
-            [MathTestToken::Add, '+'],
-            [MathTestToken::Number, '2'],
-            [MathTestToken::Subtract, '-'],
-            [MathTestToken::Number, '3'],
-            [MathTestToken::Multiply, '*'],
-            [MathTestToken::Number, '4'],
-            [MathTestToken::Divide, '/'],
-            [MathTestToken::Number, '5'],
+        ->toMatchArray([
+            [MathTestToken::Number, '1', new Span(0, 1)],
+            [MathTestToken::Add, '+', new Span(2, 3)],
+            [MathTestToken::Number, '2', new Span(4, 5)],
+            [MathTestToken::Subtract, '-', new Span(6, 7)],
+            [MathTestToken::Number, '3', new Span(8, 9)],
+            [MathTestToken::Multiply, '*', new Span(10, 11)],
+            [MathTestToken::Number, '4', new Span(12, 13)],
+            [MathTestToken::Divide, '/', new Span(14, 15)],
+            [MathTestToken::Number, '5', new Span(16, 17)],
         ]);
 });
 
@@ -41,10 +42,10 @@ it('produces the specified error token type when encountering an unexpected char
         ->build();
 
     expect($lexer->tokenise('1 % 2'))
-        ->toBe([
-            [MathTestTokenWithError::Number, '1'],
-            [MathTestTokenWithError::Error, '%'],
-            [MathTestTokenWithError::Number, '2'],
+        ->toMatchArray([
+            [MathTestTokenWithError::Number, '1', new Span(0, 1)],
+            [MathTestTokenWithError::Error, '%', new Span(2, 3)],
+            [MathTestTokenWithError::Number, '2', new Span(4, 5)],
         ]);
 });
 


### PR DESCRIPTION
Adds a new `Span` type that has a `start` and `end` offset. Represents the first and last byte position of the token in the original string / source text.