### PR TITLE
feature: add experimental lexer compiler

### DIFF
--- a/bin/lexer.stub
+++ b/bin/lexer.stub
@@ -1,0 +1,85 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ input }};
+use RyanChandler\Lexical\Contracts\LexerInterface;
+use RyanChandler\Lexical\Exceptions\UnexpectedCharacterException;
+use RyanChandler\Lexical\Span;
+
+// This class is auto-generated.
+class {{ class }} implements LexerInterface
+{
+    const PATTERNS = [
+{{ patterns }}
+    ];
+
+    const REGEX = '{{ regex }}';
+    const SKIP = {{ skip }};
+
+    const MARK_TO_TYPE_MAP = [
+{{ mark_to_type_map }}
+    ];
+
+    const ERROR_TYPE = {{ error_type }};
+
+    public function tokenise(string $input): array
+    {
+        $tokens = [];
+        $offset = 0;
+
+        while (isset($input[$offset])) {
+            if (self::SKIP !== null) {
+                preg_match('/'.self::SKIP.'/A', $input, $skips, 0, $offset);
+
+                if (isset($skips[0])) {
+                    $offset += strlen($skips[0]);
+
+                    continue;
+                }
+            }
+
+            if (! preg_match(self::REGEX, $input, $matches, PREG_UNMATCHED_AS_NULL, $offset)) {
+                if (self::ERROR_TYPE === null) {
+                    throw UnexpectedCharacterException::make($input[$offset], $offset);
+                }
+
+                $token = $this->findNextMatchAndProduceError($input, $offset);
+            } else {
+                for ($m = 'a'; null === $matches[$m]; $m++);
+
+                $token = [$matches[$m], self::MARK_TO_TYPE_MAP[$m]];
+            }
+
+            $start = $offset;
+            $offset += strlen($token[0]);
+            $tokens[] = [$token[1], $token[0], new Span($start, $offset)];
+        }
+
+        return $tokens;
+    }
+
+    protected function findNextMatchAndProduceError(string $input, int $offset): array
+    {
+        $patterns = [...array_keys(self::PATTERNS), self::SKIP];
+        $offsets = [];
+
+        foreach ($patterns as $pattern) {
+            if ($pattern === null) {
+                continue;
+            }
+
+            if (! preg_match('/'.$pattern.'/', $input, $matches, PREG_OFFSET_CAPTURE, $offset)) {
+                continue;
+            }
+
+            $offsets[] = $matches[0][1];
+        }
+
+        $skipped = count($offsets) > 0
+            ? substr($input, $offset, min($offsets) - $offset)
+            : substr($input, $offset, strlen($input) - $offset);
+
+        return [$skipped, self::ERROR_TYPE];
+    }
+}

--- a/bin/lexical
+++ b/bin/lexical
@@ -1,0 +1,177 @@
+#!/usr/bin/env php
+<?php
+
+namespace RyanChandler\Lexical;
+
+use Exception;
+use ReflectionEnum;
+use ReflectionEnumUnitCase;
+use RyanChandler\Lexical\Attributes\Error;
+use RyanChandler\Lexical\Attributes\Lexer;
+use RyanChandler\Lexical\Attributes\Regex;
+use RyanChandler\Lexical\Attributes\Literal;
+
+$vendorPath = dirname(__DIR__, 4) . '/vendor/autoload.php';
+$localPath = dirname(__DIR__) . '/vendor/autoload.php';
+
+require_once file_exists($vendorPath) ? $vendorPath : $localPath;
+
+function main(int $argc, array $argv): int {
+    if ($argc === 0 || has_help_flags($argv)) {
+        help();
+        return 0;
+    }
+
+    $input = get_option_value('--input', '-i', $argv);
+
+    if ($input === null) {
+        error("missing required option --input (-i)");
+        return 1;
+    }
+
+    $output = get_option_value('--output', '-o', $argv);
+
+    if ($output === null) {
+        error("missing required option --output (-o)");
+        return 1;
+    }
+
+    $path = get_option_value('--path', '-p', $argv);
+
+    if ($path === null) {
+        error("missing required option --path (-p)");
+        return 1;
+    }
+
+    try {
+        $reflection = new ReflectionEnum($input);
+    } catch (Exception $e) {
+        error("input {$input} must be an enum");
+        return 1;
+    }
+
+    $derived = $reflection->getAttributes(Lexer::class)[0] ?? null;
+    $skip = null;
+
+    if ($derived !== null) {
+        $skip = $derived->newInstance()->skip;
+    }
+
+    $cases = $input::cases();
+    $errorCase = null;
+    $patterns = [];
+
+    foreach ($cases as $case) {
+        $caseReflection = new ReflectionEnumUnitCase($input, $case->name);
+        $literal = $caseReflection->getAttributes(Literal::class)[0] ?? null;
+
+        if ($literal !== null) {
+            $patterns[preg_quote($literal->newInstance()->literal, '/')] = $case;
+
+            continue;
+        }
+
+        $regex = $caseReflection->getAttributes(Regex::class)[0] ?? null;
+
+        if ($regex !== null) {
+            $patterns[$regex->newInstance()->pattern] = $case;
+
+            continue;
+        }
+
+        $error = $caseReflection->getAttributes(Error::class)[0] ?? null;
+
+        if ($error !== null) {
+            $errorCase = $case;
+
+            continue;
+        }
+    }
+
+    $regex = '/';
+    $mark = 'a';
+    $markToTypeMap = [];
+
+    foreach ($patterns as $pattern => $type) {
+        if ($regex !== '/') {
+            $regex .= '|';
+        }
+
+        $regex .= "(?<{$mark}>{$pattern})";
+        $markToTypeMap[$mark] = $type;
+        $mark++;
+    }
+
+    $regex = $regex . '/A';
+    $class = substr($output, strrpos($output, '\\') + 1);
+    $namespace = substr($output, 0, strlen($output) - strlen($class) - 1);
+    $patternsReplacement = '';
+
+    foreach ($patterns as $pattern => $kind) {
+        $patternsReplacement .= '        ';
+        $patternsReplacement .= '"' . $pattern . '"';
+        $patternsReplacement .= ' => ';
+        $patternsReplacement .= '\\' . $kind::class . '::' . $kind->name;
+        $patternsReplacement .= ",\n";
+    }
+
+    $markToTypeMapReplacement = '';
+
+    foreach ($markToTypeMap as $mark => $kind) {
+        $markToTypeMapReplacement .= '        ';
+        $markToTypeMapReplacement .= '"' . $mark . '"';
+        $markToTypeMapReplacement .= ' => ';
+        $markToTypeMapReplacement .= '\\' . $kind::class . '::' . $kind->name;
+        $markToTypeMapReplacement .= ",\n";
+    }
+
+    $stub = file_get_contents(__DIR__ . '/lexer.stub');
+    $stub = str_replace('{{ class }}', $class, $stub);
+    $stub = str_replace('{{ namespace }}', $namespace, $stub);
+    $stub = str_replace('{{ input }}', $input, $stub);
+    $stub = str_replace('{{ patterns }}', $patternsReplacement, $stub);
+    $stub = str_replace('{{ regex }}', $regex, $stub);
+    $stub = str_replace('{{ skip }}', $skip === null ? 'null' : "'{$skip}'", $stub);
+    $stub = str_replace('{{ mark_to_type_map }}', $markToTypeMapReplacement, $stub);
+    $stub = str_replace('{{ error_type }}', $errorCase === null ? 'null' : ('\\' . $errorCase::class . '::' . $errorCase->name), $stub);
+
+    file_put_contents($path, $stub);
+
+    echo "Lexer generated.\n";
+
+    return 0;
+}
+
+function get_option_value(string $long, string $short, array $argv): ?string {
+    $index = array_search($short, $argv) !== false ? array_search($short, $argv) : array_search($long, $argv);
+
+    if ($index === false) {
+        return null;
+    }
+
+    if (! isset($argv[$index + 1])) {
+        return null;
+    }
+
+    return $argv[$index + 1];
+}
+
+function has_help_flags(array $argv): bool {
+    return in_array('-h', $argv) || in_array('--help', $argv);
+}
+
+function error(string $message) {
+    echo "\033[31;1merror:\033[0m {$message}\n";
+}
+
+function help() {
+    echo "\033[1musage:\033[0m lexical [options]\n";
+    echo "\n";
+    echo "\033[1mOPTIONS:\033[0m\n";
+    echo "    -i, --input    Fully-qualified class name to source tokens from.    (e.g. App\\Lexer\\TokenKind)\n";
+    echo "    -o, --output   Fully-qualified class name of generated lexer.       (e.g. App\\Lexer\\Lexer)\n";
+    echo "    -p, --path     Path to write source code for generated lexer.       (e.g. ./app/Lexer/Lexer.php)\n";
+    echo "    -h, --help     Display this help message.\n";
+}
+
+return main($argc - 1, array_slice($argv, 1));

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
             "phpstan/extension-installer": true
         }
     },
+    "bin": "bin/lexical",
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/Attributes/Lexer.php
+++ b/src/Attributes/Lexer.php
@@ -9,6 +9,5 @@ class Lexer
 {
     public function __construct(
         public readonly ?string $skip = null,
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Literal.php
+++ b/src/Attributes/Literal.php
@@ -9,6 +9,5 @@ class Literal
 {
     public function __construct(
         public readonly string $literal,
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Regex.php
+++ b/src/Attributes/Regex.php
@@ -9,6 +9,5 @@ class Regex
 {
     public function __construct(
         public readonly string $pattern,
-    ) {
-    }
+    ) {}
 }

--- a/src/Lexers/RuntimeLexer.php
+++ b/src/Lexers/RuntimeLexer.php
@@ -22,7 +22,7 @@ class RuntimeLexer implements LexerInterface
 
     protected array $markToTypeMap;
 
-    public function __construct(array $patterns, Closure $produceTokenUsing, string $skip = null, UnitEnum $errorType = null)
+    public function __construct(array $patterns, Closure $produceTokenUsing, ?string $skip = null, ?UnitEnum $errorType = null)
     {
         $this->patterns = $patterns;
         $this->produceTokenUsing = $produceTokenUsing;
@@ -69,7 +69,7 @@ class RuntimeLexer implements LexerInterface
 
                 $token = $this->findNextMatchAndProduceError($input, $offset);
             } else {
-                for ($m = 'a'; null === $matches[$m]; $m++);
+                for ($m = 'a'; $matches[$m] === null; $m++);
 
                 $token = [$matches[$m], $this->markToTypeMap[$m]];
             }

--- a/src/Span.php
+++ b/src/Span.php
@@ -7,6 +7,5 @@ class Span
     public function __construct(
         protected int $start,
         protected int $end,
-    ) {
-    }
+    ) {}
 }

--- a/tests/Compiler/CompiledLexerTest.php
+++ b/tests/Compiler/CompiledLexerTest.php
@@ -9,7 +9,7 @@ beforeAll(function () {
 });
 
 it('can produce the correct tokens for the given math expression', function () {
-    $lexer = new Lexer();
+    $lexer = new Lexer;
 
     expect($lexer->tokenise('1 + 2 - 3 * 4 / 5'))
         ->toMatchArray([

--- a/tests/Compiler/CompiledLexerTest.php
+++ b/tests/Compiler/CompiledLexerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use RyanChandler\Lexical\Span;
+use RyanChandler\Lexical\Tests\Compiler\Lexer;
+use RyanChandler\Lexical\Tests\Compiler\TokenKind;
+
+beforeAll(function () {
+    shell_exec('php ./bin/lexical -i RyanChandler\\\\Lexical\\\\Tests\\\\Compiler\\\\TokenKind -o RyanChandler\\\\Lexical\\\\Tests\\\\Compiler\\\\Lexer -p ./tests/Compiler/Lexer.php');
+});
+
+it('can produce the correct tokens for the given math expression', function () {
+    $lexer = new Lexer();
+
+    expect($lexer->tokenise('1 + 2 - 3 * 4 / 5'))
+        ->toMatchArray([
+            [TokenKind::Number, '1', new Span(0, 1)],
+            [TokenKind::Add, '+', new Span(2, 3)],
+            [TokenKind::Number, '2', new Span(4, 5)],
+            [TokenKind::Subtract, '-', new Span(6, 7)],
+            [TokenKind::Number, '3', new Span(8, 9)],
+            [TokenKind::Multiply, '*', new Span(10, 11)],
+            [TokenKind::Number, '4', new Span(12, 13)],
+            [TokenKind::Divide, '/', new Span(14, 15)],
+            [TokenKind::Number, '5', new Span(16, 17)],
+        ]);
+});

--- a/tests/Compiler/Lexer.php
+++ b/tests/Compiler/Lexer.php
@@ -2,6 +2,7 @@
 
 namespace RyanChandler\Lexical\Tests\Compiler;
 
+use RyanChandler\Lexical\Tests\Compiler\TokenKind;
 use RyanChandler\Lexical\Contracts\LexerInterface;
 use RyanChandler\Lexical\Exceptions\UnexpectedCharacterException;
 use RyanChandler\Lexical\Span;
@@ -10,7 +11,7 @@ use RyanChandler\Lexical\Span;
 class Lexer implements LexerInterface
 {
     const PATTERNS = [
-        '[0-9]+' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
+        "[0-9]+" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
         "\+" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
         "\-" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
         "\*" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
@@ -19,15 +20,14 @@ class Lexer implements LexerInterface
     ];
 
     const REGEX = '/(?<a>[0-9]+)|(?<b>\+)|(?<c>\-)|(?<d>\*)|(?<e>\/)/A';
-
     const SKIP = '[ \t\n\f]+';
 
     const MARK_TO_TYPE_MAP = [
-        'a' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
-        'b' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
-        'c' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
-        'd' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
-        'e' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Divide,
+        "a" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
+        "b" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
+        "c" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
+        "d" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
+        "e" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Divide,
 
     ];
 

--- a/tests/Compiler/Lexer.php
+++ b/tests/Compiler/Lexer.php
@@ -2,7 +2,6 @@
 
 namespace RyanChandler\Lexical\Tests\Compiler;
 
-use RyanChandler\Lexical\Tests\Compiler\TokenKind;
 use RyanChandler\Lexical\Contracts\LexerInterface;
 use RyanChandler\Lexical\Exceptions\UnexpectedCharacterException;
 use RyanChandler\Lexical\Span;
@@ -11,7 +10,7 @@ use RyanChandler\Lexical\Span;
 class Lexer implements LexerInterface
 {
     const PATTERNS = [
-        "[0-9]+" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
+        '[0-9]+' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
         "\+" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
         "\-" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
         "\*" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
@@ -20,14 +19,15 @@ class Lexer implements LexerInterface
     ];
 
     const REGEX = '/(?<a>[0-9]+)|(?<b>\+)|(?<c>\-)|(?<d>\*)|(?<e>\/)/A';
+
     const SKIP = '[ \t\n\f]+';
 
     const MARK_TO_TYPE_MAP = [
-        "a" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
-        "b" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
-        "c" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
-        "d" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
-        "e" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Divide,
+        'a' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
+        'b' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
+        'c' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
+        'd' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
+        'e' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Divide,
 
     ];
 
@@ -56,7 +56,7 @@ class Lexer implements LexerInterface
 
                 $token = $this->findNextMatchAndProduceError($input, $offset);
             } else {
-                for ($m = 'a'; null === $matches[$m]; $m++);
+                for ($m = 'a'; $matches[$m] === null; $m++);
 
                 $token = [$matches[$m], self::MARK_TO_TYPE_MAP[$m]];
             }

--- a/tests/Compiler/Lexer.php
+++ b/tests/Compiler/Lexer.php
@@ -2,7 +2,6 @@
 
 namespace RyanChandler\Lexical\Tests\Compiler;
 
-use RyanChandler\Lexical\Tests\Compiler\TokenKind;
 use RyanChandler\Lexical\Contracts\LexerInterface;
 use RyanChandler\Lexical\Exceptions\UnexpectedCharacterException;
 use RyanChandler\Lexical\Span;
@@ -11,7 +10,7 @@ use RyanChandler\Lexical\Span;
 class Lexer implements LexerInterface
 {
     const PATTERNS = [
-        "[0-9]+" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
+        '[0-9]+' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
         "\+" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
         "\-" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
         "\*" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
@@ -20,14 +19,15 @@ class Lexer implements LexerInterface
     ];
 
     const REGEX = '/(?<a>[0-9]+)|(?<b>\+)|(?<c>\-)|(?<d>\*)|(?<e>\/)/A';
+
     const SKIP = '[ \t\n\f]+';
 
     const MARK_TO_TYPE_MAP = [
-        "a" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
-        "b" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
-        "c" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
-        "d" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
-        "e" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Divide,
+        'a' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
+        'b' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
+        'c' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
+        'd' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
+        'e' => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Divide,
 
     ];
 

--- a/tests/Compiler/Lexer.php
+++ b/tests/Compiler/Lexer.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace RyanChandler\Lexical\Tests\Compiler;
+
+use RyanChandler\Lexical\Tests\Compiler\TokenKind;
+use RyanChandler\Lexical\Contracts\LexerInterface;
+use RyanChandler\Lexical\Exceptions\UnexpectedCharacterException;
+use RyanChandler\Lexical\Span;
+
+// This class is auto-generated.
+class Lexer implements LexerInterface
+{
+    const PATTERNS = [
+        "[0-9]+" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
+        "\+" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
+        "\-" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
+        "\*" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
+        "\/" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Divide,
+
+    ];
+
+    const REGEX = '/(?<a>[0-9]+)|(?<b>\+)|(?<c>\-)|(?<d>\*)|(?<e>\/)/A';
+    const SKIP = '[ \t\n\f]+';
+
+    const MARK_TO_TYPE_MAP = [
+        "a" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Number,
+        "b" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Add,
+        "c" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Subtract,
+        "d" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Multiply,
+        "e" => \RyanChandler\Lexical\Tests\Compiler\TokenKind::Divide,
+
+    ];
+
+    const ERROR_TYPE = \RyanChandler\Lexical\Tests\Compiler\TokenKind::Error;
+
+    public function tokenise(string $input): array
+    {
+        $tokens = [];
+        $offset = 0;
+
+        while (isset($input[$offset])) {
+            if (self::SKIP !== null) {
+                preg_match('/'.self::SKIP.'/A', $input, $skips, 0, $offset);
+
+                if (isset($skips[0])) {
+                    $offset += strlen($skips[0]);
+
+                    continue;
+                }
+            }
+
+            if (! preg_match(self::REGEX, $input, $matches, PREG_UNMATCHED_AS_NULL, $offset)) {
+                if (self::ERROR_TYPE === null) {
+                    throw UnexpectedCharacterException::make($input[$offset], $offset);
+                }
+
+                $token = $this->findNextMatchAndProduceError($input, $offset);
+            } else {
+                for ($m = 'a'; null === $matches[$m]; $m++);
+
+                $token = [$matches[$m], self::MARK_TO_TYPE_MAP[$m]];
+            }
+
+            $start = $offset;
+            $offset += strlen($token[0]);
+            $tokens[] = [$token[1], $token[0], new Span($start, $offset)];
+        }
+
+        return $tokens;
+    }
+
+    protected function findNextMatchAndProduceError(string $input, int $offset): array
+    {
+        $patterns = [...array_keys(self::PATTERNS), self::SKIP];
+        $offsets = [];
+
+        foreach ($patterns as $pattern) {
+            if ($pattern === null) {
+                continue;
+            }
+
+            if (! preg_match('/'.$pattern.'/', $input, $matches, PREG_OFFSET_CAPTURE, $offset)) {
+                continue;
+            }
+
+            $offsets[] = $matches[0][1];
+        }
+
+        $skipped = count($offsets) > 0
+            ? substr($input, $offset, min($offsets) - $offset)
+            : substr($input, $offset, strlen($input) - $offset);
+
+        return [$skipped, self::ERROR_TYPE];
+    }
+}

--- a/tests/Compiler/TokenKind.php
+++ b/tests/Compiler/TokenKind.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace RyanChandler\Lexical\Tests\Compiler;
+
+use RyanChandler\Lexical\Attributes\Error;
+use RyanChandler\Lexical\Attributes\Lexer;
+use RyanChandler\Lexical\Attributes\Literal;
+use RyanChandler\Lexical\Attributes\Regex;
+
+#[Lexer(skip: '[ \t\n\f]+')]
+enum TokenKind
+{
+    #[Regex('[0-9]+')]
+    case Number;
+
+    #[Literal('+')]
+    case Add;
+
+    #[Literal('-')]
+    case Subtract;
+
+    #[Literal('*')]
+    case Multiply;
+
+    #[Literal('/')]
+    case Divide;
+
+    #[Error]
+    case Error;
+}


### PR DESCRIPTION
Still experimenting with this but a rough first pass can be seen.

The idea here is that instead of using the `LexicalBuilder` to build up a `LexerInterface` at runtime, you can instead provide the name of an enum, name for a generated class and the path for the generated file and skip all of the reflection etc.

This could be especially useful for larger lexers that have a bunch of tokens and therefore require more runtime processing.

Right now, the class that gets generated is basically the same as the `RuntimeLexer` class. Has the same methods, but all of the constructor logic is gone.

I think for this to be made even better, we should abstract out the methods that a `LexerInterface` class might use, such as matching a specific pattern, checking for tokens, etc into a trait like `LexerUtilities` and then the compiled class and `RuntimeLexer` can use that, reducing duplication between the two.

There are also likely edge cases where a RegEx pattern contains a character that needs to be escaped before being inlined into the generated class (single quotes I think are a problem).